### PR TITLE
perf(firestore): remove N+1 reads in FirestoreHelper.getList

### DIFF
--- a/src/firestore-helper.ts
+++ b/src/firestore-helper.ts
@@ -91,21 +91,25 @@ export namespace FirestoreHelper {
     /**
      * Fetches all documents matching a Firestore query and returns their data.
      *
-     * Internally resolves the query to document references and fetches each
-     * one individually, merging document IDs into each result.
+     * Executes the query a single time and reads each document's data straight
+     * from the resulting snapshot, merging the document ID into each result.
+     * The query response already contains every matching document, so no
+     * additional per-document reads are performed.
      *
      * @param {InterfaceFirestoreQuery} options - Query descriptor including collection, filters,
      *   ordering, and limit.
      * @returns {Promise<DocumentData[]>} A Promise resolving to an array of document data objects.
      */
     public static getList = async (options: InterfaceFirestoreQuery): Promise<DocumentData[]> => {
-      const references = await this.getListRef(options);
-      let data: DocumentData[] = [];
-      for (const ref of references) {
-        const docData = await this._getDocumentSnap({reference: ref});
-        data.push(docData);
+      const ref = this.getListReference(options);
+      const snapshot = await ref.get();
+      if (!snapshot || !snapshot.docs || snapshot.empty) {
+        return [];
       }
-      return data;
+      return snapshot.docs.map((doc) => ({
+        ...doc.data(),
+        id: doc.id,
+      } as DocumentData));
     };
 
     /**

--- a/test/firestore-helper.test.ts
+++ b/test/firestore-helper.test.ts
@@ -131,6 +131,25 @@ describe('FirestoreHelper', () => {
     });
   });
 
+  describe('getList', () => {
+    it('returns document data from the query snapshot with ids merged, without per-document reads', async () => {
+      const data = await FirestoreHelper.Helper.getList({collection: 'users'});
+      expect(data).toEqual([
+        {val: 1, id: 'doc1'},
+        {val: 2, id: 'doc2'},
+      ]);
+      // The query already returns the data; no individual document gets.
+      expect(mockRefGet).not.toHaveBeenCalled();
+      expect(mockQueryGet).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns empty array when snapshot is empty', async () => {
+      mockQueryGet.mockResolvedValueOnce({empty: true, docs: []});
+      const data = await FirestoreHelper.Helper.getList({collection: 'users'});
+      expect(data).toEqual([]);
+    });
+  });
+
   describe('count', () => {
     it('returns the count from the aggregation snapshot', async () => {
       const n = await FirestoreHelper.Helper.count({collection: 'users'});


### PR DESCRIPTION
## Summary

`FirestoreHelper.getList` was fetching the same documents twice. It first ran the query via `getListRef` — which executes `query.get()` and already downloads **every matching document in full** — then threw away that data and re-fetched each document **individually and sequentially** via `_getDocumentSnap`.

For a query returning N documents this meant:
- **2× the Firestore document reads** (billed), and
- **N sequential round-trips** on top of the initial query, so latency grew linearly with result size.

This change reads the data straight from the single query snapshot, merging the document ID into each result. Same return shape, one query, no per-document reads.

## Impact / effort

Highest-impact, lowest-effort item from a 10-item performance review: a ~10-line change that halves reads and collapses N+1 round-trips into a single query, on a core list helper used throughout the library.

## Behavior

- Return value is unchanged: `DocumentData[]` with each document's data plus its `id`.
- Empty/missing snapshots still return `[]`.

## Verification

- `npm run lint` ✅
- `npm run build` ✅
- `npm test` ✅ (194 tests, added `getList` coverage asserting no per-document reads occur)

## Other opportunities identified (not in this PR)

For follow-up: hoist the ~320-entry map rebuilt per call in `special-char-to-regular.ts` (and fix its O(n²) `replace` loop), precompute the `replyStop` message map in `replace-message-text.ts`, use `.select()` for id/ref-only queries in `getListIds`/`getListRef`, and skip `JSON.stringify(undefined)` for empty bodies in `api-request.ts`.