### PR TITLE
perf(strings): hoist special-char table and make normalisation O(n)

### DIFF
--- a/src/special-char-to-regular.ts
+++ b/src/special-char-to-regular.ts
@@ -4,23 +4,13 @@
  */
 
 /**
- * Normalises non-GSM characters in a string by replacing them with their
- * closest ASCII or GSM-7 equivalents.
+ * Lookup table mapping a character's UTF-16 code unit (as returned by
+ * `String.prototype.charCodeAt(0)`) to its GSM-7 / ASCII replacement.
  *
- * Iterates over each character in the input, looks up its Unicode code point
- * in a comprehensive replacement table, and substitutes any matched character
- * with the mapped GSM-compatible replacement.  Characters not present in the
- * table are left unchanged.  Useful for preparing SMS message bodies that must
- * stay within the GSM-7 character set to avoid multi-part encoding overhead.
- *
- * @param {string|null} text - The input string to normalise, or `null`.  When `null`, an
- *   empty string is returned.
- * @returns {string} The normalised string with all recognised special characters
- *   replaced by their GSM-7 counterparts.
+ * Declared once at module scope so the ~320-entry table is built a single time
+ * on module load rather than being reconstructed on every function call.
  */
-export default (text: string | null): string => { // Definition of function and Input and Output Types.
-  let finalText = text && typeof text === 'string' && text.length > 0 ? text : '';
-  const charactersChange2 = {
+const charactersChange2: Record<number, {original: string, replace: string}> = {
     0: {original: '', replace: ''},
     3: {original: '', replace: ''},
     4: {original: '', replace: ''},
@@ -341,12 +331,29 @@ export default (text: string | null): string => { // Definition of function and 
     65380: {original: '、', replace: ','},
   };
 
-  for (const i of finalText) {
-    const character: number = i.charCodeAt(0); // Define Char Code for letter.
-    if (Object.prototype.hasOwnProperty.call(charactersChange2, character)) {
-      // Replace all characters according condition.
-      finalText = finalText.replace(i, charactersChange2[character].replace);
-    }
+/**
+ * Normalises non-GSM characters in a string by replacing them with their
+ * closest ASCII or GSM-7 equivalents.
+ *
+ * Performs a single left-to-right pass over the input, looking up each
+ * character's UTF-16 code unit in the module-level replacement table and
+ * appending either the mapped replacement or the original character.  Runs in
+ * linear time and preserves every occurrence of a mapped character.  Useful for
+ * preparing SMS message bodies that must stay within the GSM-7 character set to
+ * avoid multi-part encoding overhead.
+ *
+ * @param {string|null} text - The input string to normalise, or `null`.  When `null`, an
+ *   empty string is returned.
+ * @returns {string} The normalised string with all recognised special characters
+ *   replaced by their GSM-7 counterparts.
+ */
+export default (text: string | null): string => {
+  if (!(text && typeof text === 'string' && text.length > 0)) return '';
+  let result = '';
+  for (const character of text) {
+    const code: number = character.charCodeAt(0); // Char code for the current letter.
+    const entry = charactersChange2[code];
+    result += entry ? entry.replace : character;
   }
-  return finalText; // Return the message with changes.
+  return result; // Return the message with changes.
 };

--- a/test/special-char-to-regular.test.ts
+++ b/test/special-char-to-regular.test.ts
@@ -52,4 +52,9 @@ describe('specialCharToRegular', () => {
     const result = specialCharToRegular('résumé');
     expect(result).toBe('resume');
   });
+
+  it('replaces every occurrence of a repeated mapped character', () => {
+    expect(specialCharToRegular('ááá')).toBe('aaa');
+    expect(specialCharToRegular('á-é-í')).toBe('a-e-i');
+  });
 });


### PR DESCRIPTION
## Summary

`specialCharToRegular` (used to prepare SMS bodies for the GSM-7 charset) had two per-call performance problems:

1. **Table rebuilt every call** — the ~320-entry `charactersChange2` object literal was constructed on every invocation. Moved to a module-level constant so it's built once on load.
2. **O(n·m) replacement loop** — for each character it called `finalText.replace(char, …)`, re-scanning the whole string per mapped character. Replaced with a single linear left-to-right pass that appends either the mapped replacement or the original character.

Net result: linear time, no per-call allocation, identical output.

## Behavior

Output is unchanged for all existing cases. The new pass also handles repeated mapped characters more robustly (each occurrence is translated independently rather than relying on successive first-match `replace` calls).

## Verification

- `npm run lint` ✅
- `npm run compile` ✅
- `npm test` ✅ (195 tests; added coverage for repeated mapped characters)