### PR TITLE
perf(strings): hoist replyStop message tables to module scope

### DIFF
--- a/src/replace-message-text.ts
+++ b/src/replace-message-text.ts
@@ -7,6 +7,49 @@ import specialCharToRegular from './special-char-to-regular.js';
 import {toCamelCase} from './strings.js';
 
 /**
+ * Pre-defined opt-out instruction strings by language, each capped at 26
+ * characters to comply with carrier limits.
+ *
+ * Declared once at module scope so the tables are not rebuilt on every
+ * `replyStop` call.
+ */
+const replyStopMessages: Record<string, string[]> = {
+  // Max length: 26 characters
+  'en': [
+    'Reply STOP to end',
+    'Reply STOP to remove',
+    'Reply STOP to unsubscribe',
+    'Reply OPT OUT to end',
+    'Reply OPT OUT to remove',
+    'Reply QUIT to end',
+    'Reply QUIT to remove',
+    'Reply QUIT to unsubscribe',
+    'Reply UNSUBSCRIBE to end',
+    'Send QUIT to end',
+    'Send QUIT to remove',
+    'Send QUIT to unsubscribe',
+    'Send STOP to end',
+    'Send STOP to remove',
+    'Send STOP to unsubscribe',
+    'Send UNSUBSCRIBE to end',
+    'Send OPT OUT to end',
+    'Send OPT OUT to remove',
+  ],
+  'es': [
+    'Responde STOP para anular',
+    'Contesta STOP para anular',
+    'Envia STOP para anular',
+    'Envia STOP para cancelar',
+    'Envia STOP para detener',
+    'Envia ELIMINAR para anular',
+    'Envia CANCELAR para anular',
+    'Envia PARAR para anular',
+    'Envia PARAR para detener',
+    'Envia ELIMINAR para anular',
+  ],
+};
+
+/**
  * Selects a random locale-appropriate opt-out instruction string.
  *
  * Returns one of several pre-defined unsubscribe prompts for the given
@@ -18,42 +61,7 @@ import {toCamelCase} from './strings.js';
  * @returns {string} A randomly chosen unsubscribe instruction string for the language.
  */
 const replyStop = (language: string): string => {
-  const messages: Record<string, string[]> = {
-    // Max length: 26 characters
-    'en': [
-      'Reply STOP to end',
-      'Reply STOP to remove',
-      'Reply STOP to unsubscribe',
-      'Reply OPT OUT to end',
-      'Reply OPT OUT to remove',
-      'Reply QUIT to end',
-      'Reply QUIT to remove',
-      'Reply QUIT to unsubscribe',
-      'Reply UNSUBSCRIBE to end',
-      'Send QUIT to end',
-      'Send QUIT to remove',
-      'Send QUIT to unsubscribe',
-      'Send STOP to end',
-      'Send STOP to remove',
-      'Send STOP to unsubscribe',
-      'Send UNSUBSCRIBE to end',
-      'Send OPT OUT to end',
-      'Send OPT OUT to remove',
-    ],
-    'es': [
-      'Responde STOP para anular',
-      'Contesta STOP para anular',
-      'Envia STOP para anular',
-      'Envia STOP para cancelar',
-      'Envia STOP para detener',
-      'Envia ELIMINAR para anular',
-      'Envia CANCELAR para anular',
-      'Envia PARAR para anular',
-      'Envia PARAR para detener',
-      'Envia ELIMINAR para anular',
-    ],
-  };
-  const messagesByLanguage = Object.prototype.hasOwnProperty.call(messages, language) ? messages[language] : messages.en;
+  const messagesByLanguage = Object.prototype.hasOwnProperty.call(replyStopMessages, language) ? replyStopMessages[language] : replyStopMessages.en;
   const random = Math.floor((Math.random() * messagesByLanguage.length));
   return messagesByLanguage[random];
 };


### PR DESCRIPTION
## Summary

`replyStop` in `replace-message-text.ts` rebuilt its English and Spanish opt-out message arrays on every call. Since `replace-message-text` is invoked per rendered SMS template, this allocated the tables repeatedly on a hot path.

Moved the tables to a module-level `replyStopMessages` constant so they are built once on module load. Random selection and returned values are unchanged.

## Verification
- `npm run lint` ✅
- `npm run compile` ✅
- `npm test` (replace-message-text) ✅ (11 tests)