### PR TITLE
perf(firestore): fetch only references in getListIds/getListRef

### DIFF
--- a/src/firestore-helper.ts
+++ b/src/firestore-helper.ts
@@ -159,7 +159,8 @@ export namespace FirestoreHelper {
      */
     public static getListIds = async (options: InterfaceFirestoreQuery): Promise<string[]> => {
       const ref = this.getListReference(options);
-      const snapshot = await ref.get();
+      // Empty field mask: fetch only document references, not their field data.
+      const snapshot = await ref.select().get();
       if (!snapshot || !snapshot.docs || snapshot.empty) {
         return [];
       }
@@ -179,7 +180,8 @@ export namespace FirestoreHelper {
      */
     public static getListRef = async (options: InterfaceFirestoreQuery): Promise<DocumentReference[]> => {
       const ref = this.getListReference(options);
-      const snapshot = await ref.get();
+      // Empty field mask: fetch only document references, not their field data.
+      const snapshot = await ref.select().get();
       if (!snapshot || !snapshot.docs || snapshot.empty) {
         return [];
       }

--- a/test/firestore-helper.test.ts
+++ b/test/firestore-helper.test.ts
@@ -18,6 +18,7 @@ const mockCount = vi.fn(() => ({get: mockCountGet}));
 const mockLimit = vi.fn();
 const mockWhere = vi.fn();
 const mockOrderBy = vi.fn();
+const mockSelect = vi.fn();
 const mockQueryGet = vi.fn();
 const mockCollectionGroup = vi.fn();
 const mockCollection = vi.fn();
@@ -44,12 +45,14 @@ describe('FirestoreHelper', () => {
       orderBy: mockOrderBy,
       where: mockWhere,
       limit: mockLimit,
+      select: mockSelect,
       get: mockQueryGet,
       count: mockCount,
     };
     mockOrderBy.mockReturnValue(queryRef);
     mockWhere.mockReturnValue(queryRef);
     mockLimit.mockReturnValue(queryRef);
+    mockSelect.mockReturnValue(queryRef);
 
     // Firestore document get
     mockRefGet.mockResolvedValue({
@@ -114,6 +117,8 @@ describe('FirestoreHelper', () => {
     it('returns an array of document IDs', async () => {
       const ids = await FirestoreHelper.Helper.getListIds({collection: 'users'});
       expect(ids).toEqual(['doc1', 'doc2']);
+      // Only references are fetched, not document field data.
+      expect(mockSelect).toHaveBeenCalledWith();
     });
 
     it('returns empty array when snapshot is empty', async () => {
@@ -128,6 +133,8 @@ describe('FirestoreHelper', () => {
       const refs = await FirestoreHelper.Helper.getListRef({collection: 'users'});
       expect(refs).toHaveLength(2);
       expect(refs[0]).toBe(mockDocRef);
+      // Only references are fetched, not document field data.
+      expect(mockSelect).toHaveBeenCalledWith();
     });
   });
 


### PR DESCRIPTION
## Summary

`getListIds` and `getListRef` only need document IDs / references, but both ran the query without a field mask, so Firestore returned every matching document's **full field data** just to read `.id` / `.ref`.

Apply an empty `select()` field mask ("use an empty list to only return the references of matching documents", per the SDK) so only references come back. This cuts response payload size, network transfer, and deserialisation cost — significant for collections with large documents. Firestore still bills one read per document, but far less data crosses the wire.

`getListReference` (shared with `getList` and `count`) is untouched, so data-returning callers are unaffected.

## Verification
- `npm run lint` ✅
- `npm run compile` ✅
- `npm test` (firestore-helper) ✅ (18 tests; added assertions that select() is applied)
