### PR TITLE
test: exercise the real sharp image pipeline in an integration test

### DIFF
--- a/test/media-integration.test.ts
+++ b/test/media-integration.test.ts
@@ -1,0 +1,306 @@
+/**
+ * @license
+ * Copyright FabricElements. All Rights Reserved.
+ */
+import sharp from 'sharp';
+import {afterEach, beforeAll, beforeEach, describe, expect, it, vi} from 'vitest';
+
+/**
+ * Integration tests for the real `sharp` image pipeline.
+ *
+ * Unlike `test/media.test.ts`, this file deliberately does **not** mock `sharp`.
+ * It drives `Media.Image.bufferImage` end to end against the real library and
+ * asserts on metadata read back from the produced buffer, so a behavioural
+ * regression in the pipeline (for example after a `sharp` upgrade) fails CI.
+ */
+
+// Break the media <-> regex circular dependency by mocking regex before media loads.
+vi.mock('../src/regex.js', () => ({
+  isEmail: /email/,
+  contentTypeIsImageForSharp: /^(image\/)(jpeg|png|webp|gif)/,
+  contentTypeIsJPEG: /^(image\/)(jpeg|jpg)/,
+  isImage: /^(image\/)/,
+  isMedia: /^(application\/pdf|image|audio|video|text\/)/,
+}));
+
+vi.mock('firebase-admin/storage', () => ({
+  getStorage: vi.fn(() => ({
+    bucket: vi.fn(() => ({
+      file: vi.fn(() => ({
+        save: vi.fn().mockResolvedValue(undefined),
+        exists: vi.fn().mockResolvedValue([false]),
+        getMetadata: vi.fn().mockResolvedValue([{contentType: 'image/jpeg', size: 5000}]),
+        download: vi.fn().mockResolvedValue([Buffer.alloc(0)]),
+      })),
+    })),
+  })),
+}));
+
+vi.mock('firebase-functions/v2', () => ({
+  logger: {info: vi.fn(), warn: vi.fn(), error: vi.fn(), log: vi.fn()},
+  https: {HttpsError: class HttpsError extends Error {}},
+}));
+
+// Ensure no test in this file can reach the network.
+vi.stubGlobal('fetch', vi.fn(() => {
+  throw new Error('Network access is not allowed in tests');
+}));
+
+/**
+ * Builds an opaque single-colour PNG buffer of the requested dimensions.
+ * @param {number} width - Image width in pixels.
+ * @param {number} height - Image height in pixels.
+ * @param {number} [tone] - Grey level applied to every channel (0-255).
+ * @returns {Promise<Buffer>} A Promise resolving to the encoded PNG buffer.
+ */
+const createPng = async (width: number, height: number, tone = 120): Promise<Buffer> =>
+  sharp(Buffer.alloc(width * height * 3, tone), {
+    raw: {width, height, channels: 3},
+  }).png().toBuffer();
+
+/**
+ * Builds a two-frame animated GIF buffer of the requested frame dimensions.
+ * @param {number} width - Frame width in pixels.
+ * @param {number} height - Frame height in pixels.
+ * @returns {Promise<Buffer>} A Promise resolving to the encoded animated GIF buffer.
+ */
+const createAnimatedGif = async (width: number, height: number): Promise<Buffer> => {
+  const frames = await Promise.all([
+    createPng(width, height, 20),
+    createPng(width, height, 220),
+  ]);
+  return sharp(frames, {join: {animated: true}}).gif({loop: 0}).toBuffer();
+};
+
+describe('Media.Image.bufferImage (real sharp integration)', () => {
+  let Media: typeof import('../src/media.js').Media;
+  let squarePng: Buffer;
+  let widePng: Buffer;
+  let animatedGif: Buffer;
+
+  beforeAll(async () => {
+    const mod = await import('../src/media.js');
+    Media = mod.Media;
+    // Fixtures are generated programmatically, never committed as binaries.
+    squarePng = await createPng(128, 128);
+    widePng = await createPng(128, 64);
+    animatedGif = await createAnimatedGif(64, 64);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('format conversion', () => {
+    it('produces a real JPEG at the requested width and density', async () => {
+      // Arrange / Act
+      const result = await Media.Image.bufferImage({
+        input: squarePng,
+        maxWidth: 32,
+        format: Media.AvailableOutputFormats.jpeg,
+        quality: 80,
+      });
+      const metadata = await sharp(result.buffer).metadata();
+      // Assert
+      expect(result.contentType).toBe('image/jpeg');
+      expect(metadata.format).toBe('jpeg');
+      expect(metadata.width).toBe(32);
+      expect(metadata.height).toBe(32);
+      expect(metadata.density).toBe(72);
+    });
+
+    it('produces a real PNG when the format is derived from contentType', async () => {
+      // Arrange / Act
+      const result = await Media.Image.bufferImage({
+        input: squarePng,
+        maxWidth: 64,
+        contentType: 'image/png',
+        quality: 90,
+      });
+      const metadata = await sharp(result.buffer).metadata();
+      // Assert
+      expect(result.contentType).toBe('image/png');
+      expect(metadata.format).toBe('png');
+      expect(metadata.width).toBe(64);
+      expect(metadata.height).toBe(64);
+      expect(metadata.density).toBe(72);
+    });
+
+    it('produces a real WebP at the requested width', async () => {
+      // Arrange / Act
+      const result = await Media.Image.bufferImage({
+        input: squarePng,
+        maxWidth: 48,
+        format: Media.AvailableOutputFormats.webp,
+        quality: 75,
+      });
+      const metadata = await sharp(result.buffer).metadata();
+      // Assert
+      expect(result.contentType).toBe('image/webp');
+      expect(metadata.format).toBe('webp');
+      expect(metadata.width).toBe(48);
+      expect(metadata.height).toBe(48);
+    });
+
+    it('defaults to JPEG when neither format nor contentType is supplied', async () => {
+      // Arrange / Act
+      const result = await Media.Image.bufferImage({input: squarePng, maxWidth: 32});
+      const metadata = await sharp(result.buffer).metadata();
+      // Assert
+      expect(result.contentType).toBe('image/jpeg');
+      expect(metadata.format).toBe('jpeg');
+    });
+
+    it('lets an explicit format override the contentType-derived format', async () => {
+      // Arrange / Act
+      const result = await Media.Image.bufferImage({
+        input: squarePng,
+        maxWidth: 32,
+        contentType: 'image/png',
+        format: Media.AvailableOutputFormats.webp,
+      });
+      const metadata = await sharp(result.buffer).metadata();
+      // Assert
+      expect(result.contentType).toBe('image/webp');
+      expect(metadata.format).toBe('webp');
+    });
+  });
+
+  describe('animated GIF handling', () => {
+    it('preserves every frame of an animated GIF while resizing each page', async () => {
+      // Arrange
+      const source = await sharp(animatedGif, {animated: true}).metadata();
+      expect(source.pages).toBe(2);
+      // Act
+      const result = await Media.Image.bufferImage({
+        input: animatedGif,
+        maxWidth: 32,
+        format: Media.AvailableOutputFormats.gif,
+      });
+      const metadata = await sharp(result.buffer, {animated: true}).metadata();
+      // Assert
+      expect(result.contentType).toBe('image/gif');
+      expect(metadata.format).toBe('gif');
+      expect(metadata.pages).toBe(2);
+      expect(metadata.width).toBe(32);
+      expect(metadata.pageHeight).toBe(32);
+    });
+  });
+
+  describe('resize, crop and extract', () => {
+    it('crops a wide image to an exact square via cover resize plus extract', async () => {
+      // Arrange / Act
+      const result = await Media.Image.bufferImage({
+        input: widePng,
+        maxWidth: 32,
+        maxHeight: 32,
+        format: Media.AvailableOutputFormats.png,
+      });
+      const metadata = await sharp(result.buffer).metadata();
+      // Assert
+      expect(metadata.format).toBe('png');
+      expect(metadata.width).toBe(32);
+      expect(metadata.height).toBe(32);
+    });
+
+    it('crops with the attention strategy to the requested dimensions', async () => {
+      // Arrange / Act
+      const result = await Media.Image.bufferImage({
+        input: widePng,
+        maxWidth: 40,
+        maxHeight: 20,
+        crop: 'attention',
+        format: Media.AvailableOutputFormats.jpeg,
+      });
+      const metadata = await sharp(result.buffer).metadata();
+      // Assert
+      expect(metadata.format).toBe('jpeg');
+      expect(metadata.width).toBe(40);
+      expect(metadata.height).toBe(20);
+    });
+
+    it('does not enlarge an image smaller than the requested width', async () => {
+      // Arrange
+      const small = await createPng(16, 16);
+      // Act
+      const result = await Media.Image.bufferImage({
+        input: small,
+        maxWidth: 200,
+        format: Media.AvailableOutputFormats.png,
+      });
+      const metadata = await sharp(result.buffer).metadata();
+      // Assert
+      expect(metadata.width).toBe(16);
+      expect(metadata.height).toBe(16);
+    });
+  });
+
+  describe('device pixel ratio', () => {
+    it('scales dimensions and density by the device pixel ratio', async () => {
+      // Arrange / Act
+      const result = await Media.Image.bufferImage({
+        input: squarePng,
+        maxWidth: 32,
+        dpr: 2,
+        format: Media.AvailableOutputFormats.jpeg,
+      });
+      const metadata = await sharp(result.buffer).metadata();
+      // Assert
+      expect(metadata.width).toBe(64);
+      expect(metadata.density).toBe(144);
+    });
+
+    it('clamps a device pixel ratio above 6 down to 6', async () => {
+      // Arrange / Act
+      const result = await Media.Image.bufferImage({
+        input: squarePng,
+        maxWidth: 10,
+        dpr: 12,
+        format: Media.AvailableOutputFormats.png,
+      });
+      const metadata = await sharp(result.buffer).metadata();
+      // Assert
+      expect(metadata.width).toBe(60);
+      expect(metadata.density).toBe(432);
+    });
+  });
+
+  describe('quality', () => {
+    it('yields a smaller JPEG buffer at a lower quality setting', async () => {
+      // Arrange
+      const detailed = await sharp({
+        create: {width: 128, height: 128, channels: 3, noise: {type: 'gaussian', mean: 128, sigma: 60}},
+      }).png().toBuffer();
+      // Act
+      const low = await Media.Image.bufferImage({
+        input: detailed,
+        maxWidth: 128,
+        format: Media.AvailableOutputFormats.jpeg,
+        quality: 20,
+      });
+      const high = await Media.Image.bufferImage({
+        input: detailed,
+        maxWidth: 128,
+        format: Media.AvailableOutputFormats.jpeg,
+        quality: 95,
+      });
+      // Assert
+      expect(low.buffer.length).toBeLessThan(high.buffer.length);
+    });
+  });
+
+  describe('invalid input', () => {
+    it('rejects a buffer that is not a supported image', async () => {
+      // Arrange / Act / Assert
+      await expect(Media.Image.bufferImage({
+        input: Buffer.from('not-an-image'),
+        maxWidth: 32,
+        format: Media.AvailableOutputFormats.jpeg,
+      })).rejects.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
## The gap

`test/media.test.ts` line 16 calls `vi.mock('sharp', …)`, replacing sharp with a stub of `vi.fn()`s. That means the whole suite (195 tests / 18 files before this PR) **never executed real image-processing code** — it only verified this package's branching and argument passing.

That matters right now: `main` recently merged `a5aff2c` (#72), which bumped sharp `0.34.5 → 0.35.3` to patch four HIGH severity libvips CVEs and adapted `src/media.ts` for the narrowed `toFormat` parameter type. CI could not have caught a behavioural regression there, because sharp was mocked; the bump was only smoke-tested by hand. This PR makes that verification permanent and automatic.

## What this adds

A new `test/media-integration.test.ts` that does **not** mock sharp and drives the package's own public entry point, `Media.Image.bufferImage`, through the exact pipeline `src/media.ts` uses:

```
sharp(input, {animated}) → .resize(fit/position) → .extract(…) → .withMetadata({density: dpr * 72}) → .toFormat(format, {force, quality}) → .toBuffer()
```

Every assertion is on **observed output** — metadata read back from the produced buffer via `sharp(result.buffer).metadata()` — never on constructor arguments or call spies.

13 tests covering:

| Area | Cases |
| --- | --- |
| Formats | `jpeg` (explicit + default fallback), `png` (derived from `contentType`), `webp`, `format` overriding `contentType` |
| Animated `gif` | 2-frame animated GIF in → 2 pages out, `pageHeight` resized per frame |
| Resize / crop / extract | cover-resize + `extract` to an exact square, `crop: 'attention'` to non-square dimensions, `withoutEnlargement` on an undersized input |
| DPR | `dpr: 2` → 2× dimensions and `density` 144; `dpr: 12` clamped to 6 → `density` 432 |
| Quality | lower `quality` produces a smaller JPEG buffer than higher `quality` |
| Invalid input | a non-image buffer rejects |

`density` is asserted for `jpeg` and `png` (72 / 144 / 432 = `dpr * 72`), the one piece of metadata this package deliberately sets. It is **not** asserted for `webp` or `gif`: sharp reports `density: undefined` when reading those containers back, so there is nothing observable to assert. Noted here rather than worked around.

Fixtures are generated programmatically with sharp at setup (solid-colour raw buffers → PNG; two PNGs joined via `{join: {animated: true}}` → animated GIF). **No binary image files are committed.** No network access — `fetch` is stubbed to throw. Firebase Storage and the functions logger are stubbed as usual; only sharp is real.

## Existing tests unchanged

`test/media.test.ts` is **not** modified or weakened — the fast mocked unit tests and this real-library integration test coexist.

## Verification

- `npm run lint` — clean
- `npm run build` — clean
- `npm test` — **208 tests / 19 files passing** (baseline was 195 / 18; +13 tests, +1 file, no pre-existing test changed)
- Suite runtime: ~307 ms → ~428 ms locally; the new file adds roughly **0.12–0.2 s** (170 ms wall when run alone).

### The test has teeth

Deliberately broken twice and confirmed to fail, then reverted:

- asserted the JPEG case produced `png` → `AssertionError: expected 'jpeg' to be 'png'`
- asserted `density` was `96` instead of `72` → `AssertionError: expected 72 to be 96`

## Scope

Tests only. **Nothing under `src/` is changed**, and `package.json` / `package-lock.json` / the `sharp` version are untouched.