### PR TITLE
fix(deps): patch websocket-driver and brace-expansion security advisories

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2791,16 +2791,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/buffer-equal-constant-time": {
@@ -4153,9 +4153,9 @@
       "license": "MIT"
     },
     "node_modules/glob/node_modules/brace-expansion": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
-      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.4.tgz",
+      "integrity": "sha512-hGfVzPxthbf3+2yjg/RBs60cB0FhqBS/zvdV/4wn4/BmN0bNMMHPc4V/BbFieqf1TKAGGAHnY4eSjajCl0f2Xg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
@@ -6634,9 +6634,9 @@
       "optional": true
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",


### PR DESCRIPTION
## Summary

Clears the fixable open Dependabot security alerts, including the **CRITICAL** `websocket-driver` one. All alerts are on **transitive** dependencies — none is a direct dependency in `package.json`.

The change was made with a **targeted `npm update websocket-driver brace-expansion`** — the least invasive mechanism that reaches the patched versions. No `npm audit fix --force`, no blanket `npm update`, no lockfile regeneration, and **no `overrides` entry was necessary**. The resulting diff is **`package-lock.json` only, 10 insertions / 10 deletions, touching exactly 3 package entries.**

## Alert status

| Severity | Package | Path | Before | After | Status |
|---|---|---|---|---|---|
| **CRITICAL** (#114) | `websocket-driver` | `node_modules/websocket-driver` | `0.7.4` | **`0.7.5`** | ✅ Resolved |
| MEDIUM (#115) | `websocket-driver` | `node_modules/websocket-driver` | `0.7.4` | **`0.7.5`** | ✅ Resolved |
| HIGH (#116, dev) | `brace-expansion` | `node_modules/brace-expansion` | `5.0.6` | **`5.0.9`** | ✅ Resolved |
| HIGH (#119) | `brace-expansion` | `node_modules/glob/node_modules/brace-expansion` | `2.1.1` | **`2.1.4`** | ✅ Resolved |
| HIGH (#124) | `brace-expansion` | `node_modules/glob/node_modules/brace-expansion` | `2.1.1` | **`2.1.4`** | ✅ Resolved |
| HIGH (#126) | `brace-expansion` | `node_modules/glob/node_modules/brace-expansion` | `2.1.1` | **`2.1.4`** | ✅ Resolved |
| MEDIUM (#107) | `uuid` | `node_modules/uuid` | `9.0.1` | `9.0.1` | ⚠️ **Deliberately deferred** — see below |

Advisories cleared: GHSA-mp7j-qc5w-4988, GHSA-xv26-6w52-cph6 (websocket-driver); GHSA-3jxr-9vmj-r5cp, GHSA-mh99-v99m-4gvg, GHSA-rgw5-rvv9-x895 (brace-expansion).

### One discrepancy vs. the reported alert data

The dev-tree `brace-expansion` alert listed `5.0.7` as first-patched, but `npm audit` reports the vulnerable range as `2.0.0 - 2.1.3 || 3.0.0 - 5.0.8` — i.e. **`5.0.7` and `5.0.8` are still vulnerable** under the two later advisories. `npm update` correctly resolved to **`5.0.9`** (current latest), which clears it. The three nested `2.x` alerts were cumulative as expected and are all satisfied by `2.1.4`.

## Lockfile verification (all entries, including nested copies)

Parsed directly out of `package-lock.json` post-change:

```
=== websocket-driver ===
  node_modules/websocket-driver              ->  0.7.5
=== brace-expansion ===
  node_modules/brace-expansion               ->  5.0.9  (dev)
  node_modules/glob/node_modules/brace-expansion  ->  2.1.4
=== uuid ===
  node_modules/uuid                          ->  9.0.1
```

These are the *only* entries for each of those packages anywhere in the lockfile — there are no other nested copies.

## `sharp` is untouched ✅

```
=== sharp ===
  node_modules/sharp  ->  0.35.3
```

All 22 `@img/sharp-*` platform binaries remain at `0.35.3` and all `@img/sharp-libvips-*` at `1.3.2`. **No `sharp` entry anywhere in the lockfile is below `0.35.0`.** The libvips CVE patch from a5aff2c is fully preserved, and `src/media.ts` is not modified.

## Why `uuid` (#107) is deferred rather than forced

Fixing it requires `9.0.1 → 11.1.1`, crossing **two major versions** of a package that is purely transitive. I traced the actual parents:

```
firebase-admin@13.10.0
├─┬ @google-cloud/firestore@7.11.6
│ └─┬ google-gax@4.6.1
│   ├─┬ retry-request@7.0.2 → teeny-request@9.0.0 → uuid@9.0.1
│   └── uuid@9.0.1
└─┬ @google-cloud/storage@7.21.0
  ├─┬ gaxios@6.7.1 → uuid@9.0.1
  └─┬ teeny-request@9.0.0 → uuid@9.0.1
```

Per the guidance, I checked for a **parent** fix instead of overriding the child:

- `gaxios@6.7.1` is the **last release of the 6.x line** (fix is in 7.x).
- `teeny-request@9.0.0` is the **last release of the 9.x line** (fix is in 11.x).
- `google-gax@4.6.1` is the last of the 4.x line reachable here.
- `firebase-admin@13.10.0` is the **latest 13.x release**, and `package.json` declares `^13.10.0`.

So there is **no in-range parent update** that resolves it. `npm audit` confirms the only automated path is `firebase-admin@14.3.0`, flagged as a breaking change. That would be a **major bump of a direct dependency** of a library consumed by other repositories (e.g. `furcata/functions` consumes it as a git dependency), so it does not belong in a lockfile-only security patch and should be its own reviewed PR. Encouragingly, `firebase-admin@14.3.0` keeps `engines.node: ">=22"`, so that follow-up should not change this package's engine contract.

An `overrides` entry pinning `uuid@11` was explicitly rejected: it would force `uuid@11` onto Firestore/Storage code paths that only ever declared support for `uuid@9`, at runtime, for every downstream consumer. A documented deferred MEDIUM is preferable to a silent runtime break.

**Recommended follow-up:** a dedicated PR evaluating `firebase-admin@^14`, which resolves #107 in full.

## Final `npm audit`

Before: `11 vulnerabilities (9 moderate, 1 high, 1 critical)`
After: **`9 moderate severity vulnerabilities`** — **0 critical, 0 high.**

Every remaining moderate is the *same single* `uuid` advisory (GHSA-w5hq-g745-h8pq) rolled up through its dependency chain (`gaxios`, `teeny-request`, `retry-request`, `google-gax`, `@google-cloud/firestore`, `@google-cloud/storage`, `firebase-admin`, `firebase-functions`). There is no second unfixed issue hiding in that count.

## Verification

- `npm run lint` — clean
- `npm run build` — clean (`rm -rf ./lib` + eslint + tsc)
- `npm test` — **195 tests passed across 18 test files**, matching the stated baseline exactly

## Scope

Dependency files only — **`package-lock.json` is the single changed file.** No `package.json` change was needed (no `overrides` proved necessary). Nothing under `src/` or `test/` is touched, leaving room for the sibling session's `test/media-integration.test.ts`. No change to the public API or to declared `engines`.