### PR TITLE
docs(sec): document the claims-promotion mechanism and add the round-2 tests

### DIFF
--- a/.github/instructions/security.instructions.md
+++ b/.github/instructions/security.instructions.md
@@ -28,13 +28,13 @@ and patching one consumer's call site does not fix the package.
 
 This is not hypothetical. It is the defect this file was written from:
 
-- `src/user.ts:551` — `formatUserNames` returns `{...data, …}`. It is a *formatter*, not a
+- `src/user.ts:596` — `formatUserNames` returns `{...data, …}`. It is a *formatter*, not a
   filter: every caller-supplied key survives it.
 - Before the fix, `createUser` built `{...formatNames, role: 'user', group: undefined,
   password: undefined}` — a **denylist** that reset three known scalars.
 - A nested authorization map (`groups: {tenant: 'owner'}`) is not a scalar, so it passed
-  straight through into `set(…, {merge: true})` at `src/user.ts:261`.
-- Worse, `src/user.ts:900` copies the document's `groups` map into Firebase Auth **custom
+  straight through into `set(…, {merge: true})` at `src/user.ts:306`.
+- Worse, `src/user.ts:997` copies the document's `groups` map into Firebase Auth **custom
   claims** on the next role update. An injected map is therefore promoted from "a field in
   a document" to "a signed claim in a token".
 
@@ -43,18 +43,43 @@ This is not hypothetical. It is the defect this file was written from:
 > **Reset or reject by allow-list, never by denylist.** When you accept a caller object and
 > write it somewhere sensitive, enumerate the fields you *permit*.
 
-The fix is `src/user.ts:125` (`creatableProfileFields`, the allow-list) applied by
-`src/user.ts:723` (`Helper.sanitizeProfile`) at the sink in `src/user.ts:786`.
+The fix is `src/user.ts:177` (`creatableProfileFields`, the allow-list) applied by
+`src/user.ts:769` (`Helper.sanitizeProfile`) at the sink in `src/user.ts:834`.
 A denylist is only correct until someone adds a field; an allow-list fails safe against the
 next field nobody thought of.
 
 **Consequences for new code:**
 
+### Choosing what goes in an allow-list: "who knows the correct value?"
+
+An allow-list is only as good as its admission rule. The first version of
+`creatableProfileFields` used "the declared non-authorization fields of `User.Interface`".
+That rule is coherent, and it was **wrong** — it admitted `bcId`, `bsId`, `bsiId`, `bst`,
+`but`, `buq` (payment-provider identity and metering) and `account` (the user's *active*
+account, i.e. a tenancy pointer). None are authorization fields, so the rule let them in,
+and a caller could choose their own billing identity at creation.
+
+The rule that replaced it:
+
+> **Admit a field only if the caller is the party who knows its correct value.**
+
+- `ads` — the user's own ad-network placement identifiers. The user knows them; the server
+  does not. **Creatable.**
+- `bcId` — identifies a record inside a payment provider, produced by a server-side call to
+  it. A caller supplying one is mistaken or malicious. **Server-only.**
+
+`serverOnlyFields` (`src/user.ts:136`) enumerates the excluded set and is exported so
+consumers can assert the same rule in their own validation and security rules.
+`test/user.test.ts` asserts the two lists stay **disjoint**, so a future field cannot
+quietly appear in both.
+
 - Any new helper that accepts a caller object and writes it to Firestore, Storage, Auth
   claims, or BigQuery must reduce it through an allow-list first.
-- `src/user.ts:261` (`Helper.createDocument`) is deliberately **unfiltered** — it is the
-  low-level writer used by server-authored paths such as `onCreate`. Its JSDoc says so.
-  Do not "fix" it by filtering; do not call it with untrusted input either.
+- `src/user.ts:293` (`Helper.createDocument`) is deliberately **unfiltered** — it is the
+  low-level writer used by server-authored paths such as `onCreate`, and it is the
+  sanctioned way to seed a server-only field such as `bcId` once the server knows the
+  correct value. Its JSDoc says so. Do not "fix" it by filtering; do not call it with
+  untrusted input either.
 
 ## 2. Spread ordering is a security property
 
@@ -69,15 +94,15 @@ Sweep with a bare `\.\.\.` across `src/` and classify every hit.
 
 Audited hits:
 
-- ✅ `src/user.ts:786` — server-authored `role: 'user'` follows the spread.
-- ✅ `src/user.ts:655`, `src/firestore-helper.ts:110`, `src/firestore-helper.ts:251` —
+- ✅ `src/user.ts:834` — server-authored `role: 'user'` follows the spread.
+- ✅ `src/user.ts:700`, `src/firestore-helper.ts:110`, `src/firestore-helper.ts:251` —
   server keys (`updated`, `backup`, `id`) all follow the spread.
 - ⚠️ `src/media.ts:464` — `{contentType, resumable: false, validation: true,
   ...options.options}` spreads **after** the server keys, so a caller can set
   `validation: false` and disable upload integrity checking. This is an intentional
   escape hatch for Cloud Storage save options; it is safe **only** because `options.options`
   is developer-supplied. Never forward a request body into it.
-- ⚠️ `src/user.ts:297` — `{...userDoc, ...doc.data()}` lets an existing Firestore document
+- ⚠️ `src/user.ts:342` — `{...userDoc, ...doc.data()}` lets an existing Firestore document
   override the server default `role: 'user'`. This is intentional (a pre-provisioned invite
   should win) and the spread source is a server-side read, not caller input — but it means
   **write access to `user/{uid}` is equivalent to role assignment**. Keep `firestore.rules`
@@ -85,7 +110,7 @@ Audited hits:
 
 ## 3. Validate outbound URLs (SSRF)
 
-`src/user.ts:306` passes a Firebase Auth `photoURL` — which originates with the identity
+`src/user.ts:351` passes a Firebase Auth `photoURL` — which originates with the identity
 provider or the account creator, not with you — into `Media.Helper.saveFromUrl`. Before the
 fix that reached a bare `fetch(url, {redirect: 'follow'})` with no timeout, no size cap, and
 no address checks.
@@ -121,7 +146,7 @@ cannot be parameterised, so they need an **anchored** pattern check first.
 - ✅ `src/bigquery-identifier.ts` is the single canonical validator. Both
   `src/cleaner.ts` and `src/bigquery-stream-writer.ts:133` import it. Do **not** re-implement
   it — two copies of one security primitive will drift, and one will end up weaker.
-- ⚠️ `src/user.ts:866` — `{[data.group]: _role}` uses a caller-supplied `group` as a
+- ⚠️ `src/user.ts:936` — `{[data.group]: _role}` uses a caller-supplied `group` as a
   Firestore map key. Validate `group` against an allow-list at your call site before
   invoking `updateRole`/`remove`.
 - ⚠️ `src/firestore-helper.ts:133`, `:230` — `collection`, `collectionGroup` and `document`
@@ -161,11 +186,52 @@ capacity or balance is a race.
 Consumers will trust these. `src/user.ts` `getRole`, `updateRole`, `roleUpdateCall` and the
 `groups` map are authorization surface:
 
-- `Helper.authenticated` (`src/user.ts:167`) only proves *authentication*. It is not an
+- `Helper.authenticated` (`src/user.ts:212`) only proves *authentication*. It is not an
   authorization check. Callers must still verify the caller may act on the target user.
 - `updateRole`/`remove` are privileged admin operations with **no built-in caller
   authorization**. The consuming callable/HTTP trigger must authorize before invoking them.
 - Never trust a client-supplied uid, role, group, or ownership claim.
+
+### 🔴 This library promotes document state into signed ID tokens
+
+`roleUpdateCall` copies the `groups` map into Firebase Auth **custom claims** via
+`setCustomUserClaims`. Consumers frequently do not realise this happens, because the call
+lives *here*, in a dependency, and not in their own codebase — a system can show users
+holding a `role` claim while `setCustomUserClaims` appears nowhere in its source.
+
+The consequences are load-bearing and must not be lost:
+
+- **Write access to `user/{uid}` is equivalent to role assignment.** Anything able to
+  influence that document's `groups` field can influence a signed token that every relying
+  party then treats as verified identity.
+- **A claim outlives the document.** Deleting or cleaning up `user/{uid}` does not retract
+  a claim already minted into a token.
+- This is what turned the §1 escalation from "a stray field in a document" into "a signed
+  assertion of privilege", and it is why `groups` is in `serverOnlyFields`.
+
+Keep security rules default-deny on `user/{uid}`.
+
+### De-provisioning is not immediate unless the consumer checks
+
+Two distinct failure modes were found in this path, both now fixed — understand them before
+touching it:
+
+1. **Stale claims.** Claims were rebuilt from `userDoc`, the **pre-write** snapshot, so
+   published claims lagged by one update: a removal left the removed group in the token
+   indefinitely, and the first grant published nothing. Always derive the resulting state
+   locally rather than reading back a snapshot taken before the write.
+2. **No revocation.** The `revokeRefreshTokens` call after `setCustomUserClaims` was
+   commented out, so a de-provisioned user kept a validly-signed token with the **old**
+   claims until natural expiry. It now fires when authority is withdrawn (`remove`) or an
+   existing role is replaced. A pure grant does not revoke — the new claim applies at the
+   next refresh, and forcing re-authentication there is a UX cost with no security benefit.
+   Because roles are opaque strings the library cannot rank them, so any change to an
+   existing value is treated as potentially a downgrade.
+
+> ⚠️ **Revoking refresh tokens does not invalidate outstanding ID tokens.** They remain
+> cryptographically valid until they expire (up to an hour) unless the relying party calls
+> `getAuth().verifyIdToken(token, true)`. A fix here without that flag on the consumer side
+> produces *false confidence*, not immediate de-provisioning. Document both halves, always.
 
 ## 8. Evidence standards for security changes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,50 @@ Prior releases are tracked through Git history and GitHub Releases.
   write. **Consumers should treat this as a priority upgrade**, especially if they pin an
   exact commit: a fix on `main` is not a fix in production until the pin moves.
 
+- **Caller-supplied billing and tenancy fields can no longer reach a user document.**
+  The creation allow-list was originally derived as "the declared non-authorization
+  fields of `User.Interface`". That rule is coherent but it admitted `bcId`, `bsId`,
+  `bsiId`, `bst`, `but` and `buq` — **payment-provider identity and metering state** —
+  along with `account`, which designates the user's *active* account and is therefore a
+  tenancy pointer. A consumer passing an unvalidated request body let the requester
+  choose their own billing identity at creation, e.g. pointing `bcId` at another
+  tenant's customer record. All seven are now excluded and are enumerated in the new
+  exported `User.serverOnlyFields`. The test for admitting a field is now **"who knows
+  the correct value?"** — `ads` stays creatable because it holds the user's own
+  ad-network placement identifiers; `bcId` does not, because only the payment provider
+  and the server ever know it.
+
+- **Group role removal now actually removes the claim.** `roleUpdateCall` rebuilt the
+  `groups` custom claim from `userDoc`, which is the **pre-write** snapshot, so
+  published claims lagged the change by one update: removing a group left the removed
+  group in the user's token indefinitely, and the very first group grant published no
+  claim at all. The resulting map is now derived locally, so removals and first grants
+  are both reflected immediately.
+
+- **Refresh tokens are revoked when authority is withdrawn or replaced.** The
+  `revokeRefreshTokens` call following `setCustomUserClaims` was commented out, so a
+  de-provisioned user kept a validly-signed token carrying the **old** claims until
+  natural expiry. It is now called when a role or group is removed, or when an existing
+  role is replaced with a different one. A pure grant does not revoke, since the new
+  claim takes effect on the next refresh anyway and forcing re-authentication there has
+  a UX cost with no security benefit.
+
+  ⚠️ **Revocation is not instantaneous by itself.** Already-issued ID tokens remain
+  cryptographically valid until they expire (up to one hour) unless the relying party
+  verifies them with `getAuth().verifyIdToken(token, true)`. Consumers needing immediate
+  de-provisioning **must** pass that `checkRevoked` flag and treat claim removal as
+  eventually consistent.
+
+- **Documented: this library promotes Firestore document state into signed ID tokens.**
+  `roleUpdateCall` copies the `groups` map from `user/{uid}` into Firebase Auth custom
+  claims via `setCustomUserClaims`. Consumers may not realise the call happens at all,
+  because it lives here rather than in their own codebase. The practical consequence is
+  that **write access to `user/{uid}` is equivalent to role assignment**: anything able
+  to influence that document's `groups` field can influence a signed token that is then
+  presented to every relying party as verified identity — and which outlives deletion of
+  the document itself. This is what made the escalation above more than a stray field.
+  Keep security rules default-deny on `user/{uid}`.
+
 - **`Media.Helper.saveFromUrl` is now SSRF-guarded.** It previously issued a bare
   `fetch(url, {redirect: 'follow'})` with no timeout, no size cap, and no address checks,
   and it is reachable with a URL that originates outside the server (a Firebase Auth
@@ -49,6 +93,10 @@ Prior releases are tracked through Git history and GitHub Releases.
 
 - `outboundUrl` (`src/outbound-url.ts`) — `assertSafeOutboundUrl`, `safeFetch` and
   `isBlockedAddress` for any helper that fetches a caller-influenced URL.
+- `User.serverOnlyFields` — the explicit list of fields that must never be accepted from
+  a caller (authorization state, billing/provider identity, `account`, credentials and
+  server bookkeeping), exported so consumers can assert the same rule in their own
+  validation and security rules rather than re-deriving it.
 - `validateBigQueryIdentifier` (`src/bigquery-identifier.ts`) — the single canonical
   BigQuery identifier validator, now shared by `cleaner` and `BigQueryStreamWriter`.
 - `User.Helper.sanitizeProfile` and `User.creatableProfileFields` — the allow-list used by
@@ -60,8 +108,11 @@ Prior releases are tracked through Git history and GitHub Releases.
 ### Changed
 
 - **BREAKING —** `User.Helper.create` now persists **only** the fields listed in
-  `User.creatableProfileFields`. Undeclared keys and authorization fields are dropped
-  instead of written.
+  `User.creatableProfileFields`. Undeclared keys, authorization fields, billing/provider
+  identity fields and the `account` tenancy pointer are dropped instead of written.
+- **BREAKING —** `User.Helper.updateRole` and `User.Helper.remove` now revoke the user's
+  refresh tokens when a role or group is withdrawn or replaced, forcing re-authentication
+  on those paths.
 - **BREAKING —** `Media.Helper.saveFromUrl` now throws for URLs that fail SSRF validation
   (non-`http(s)` schemes, embedded credentials, unresolvable hosts, or hosts resolving to a
   blocked range) and for responses larger than 25 MiB.
@@ -90,6 +141,27 @@ If you relied on a custom field being persisted at creation time, either add it 
 follow-up write via `User.Helper.createDocument` (which is unfiltered by design and must
 only receive server-authored data), or open an issue to have the field added to
 `creatableProfileFields`.
+
+Billing identity must now be seeded explicitly from server code that already knows the
+correct value, rather than arriving inside a caller's profile blob:
+
+```ts
+const user = await User.Helper.create(request.body);
+// Server-side: create the provider record first, then write the id you got back.
+const customer = await billingProvider.customers.create({email: user.email});
+await User.Helper.createDocument({id: user.id, bcId: customer.id});
+```
+
+Role changes now revoke refresh tokens when authority is withdrawn or replaced. To act on
+that immediately, verify ID tokens with the `checkRevoked` flag:
+
+```ts
+// Before: a de-provisioned user's existing token stayed valid until expiry.
+const decoded = await getAuth().verifyIdToken(token);
+
+// 2.0.0: detect revocation, and treat claim removal as eventually consistent.
+const decoded = await getAuth().verifyIdToken(token, true);
+```
 
 `Media.Helper.saveFromUrl` — if you were passing an internal or emulator URL, fetch it
 yourself and use `Media.Helper.save` with the resulting buffer.

--- a/README.MD
+++ b/README.MD
@@ -77,13 +77,26 @@ These contracts are deliberate; relying on the opposite behaviour is unsafe.
 
 - **`User.Helper.create` filters its input.** Only the fields in
   `User.creatableProfileFields` are persisted to the new `user/{uid}` document.
-  Authorization state (`role`, `group`, `groups`), credentials (`password`) and
-  server-managed bookkeeping are dropped, and the new account always starts with the
+  Authorization state (`role`, `group`, `groups`), billing/provider identity (`bcId`,
+  `bsId`, `bsiId`, `bst`, `but`, `buq`), the `account` tenancy pointer, credentials
+  (`password`) and server-managed bookkeeping are dropped — the full excluded set is
+  exported as `User.serverOnlyFields`. The new account always starts with the
   server-assigned role `'user'`. Use `User.Helper.sanitizeProfile` to apply the same
   filter at your own call sites. See the [migration note](CHANGELOG.md) if you previously
   relied on extra fields being written.
 - **`User.Helper.createDocument` does *not* filter.** It is the low-level writer for
-  server-authored objects. Never hand it an unvalidated request body.
+  server-authored objects, and the sanctioned way to seed a server-only field such as
+  `bcId` once your server knows the correct value. Never hand it an unvalidated request
+  body.
+- **Role changes write Firebase Auth custom claims.** `User.Helper.updateRole` and
+  `User.Helper.remove` copy the user's `groups` map into custom claims, which are embedded
+  in every ID token and presented to relying parties as verified identity. **Treat write
+  access to `user/{uid}` as equivalent to role assignment** and keep your security rules
+  default-deny on that path.
+- **De-provisioning needs `checkRevoked` on your side.** Withdrawing or replacing a role
+  revokes the user's refresh tokens, but already-issued ID tokens stay valid until they
+  expire (up to an hour) unless you verify with `getAuth().verifyIdToken(token, true)`.
+  Treat claim removal as eventually consistent.
 - **`Media.Helper.saveFromUrl` validates the URL** through
   `outboundUrl.assertSafeOutboundUrl`, re-validates every redirect hop, applies a timeout,
   and caps the response size. Private, loopback, link-local and cloud metadata addresses

--- a/test/user.test.ts
+++ b/test/user.test.ts
@@ -278,3 +278,78 @@ describe('User.Helper.create — caller-supplied authorization fields', () => {
     }
   });
 });
+
+describe('User.Helper role changes — custom claims and token revocation', () => {
+  /**
+   * Returns the claims object handed to the most recent `setCustomUserClaims` call.
+   *
+   * @returns {object} The published custom claims.
+   */
+  const publishedClaims = (): {role?: string, groups?: Record<string, string>} => {
+    expect(mockSetCustomUserClaims).toHaveBeenCalled();
+    return mockSetCustomUserClaims.mock.calls[mockSetCustomUserClaims.mock.calls.length - 1][1];
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSet.mockResolvedValue(undefined);
+    mockDoc.mockReturnValue({set: mockSet, delete: vi.fn().mockResolvedValue(undefined)});
+    mockCollection.mockReturnValue({doc: mockDoc});
+    mockSetCustomUserClaims.mockResolvedValue(undefined);
+    mockRevokeRefreshTokens.mockResolvedValue(undefined);
+    mockUpdateUser.mockResolvedValue(undefined);
+    mockGetUser.mockResolvedValue({
+      uid: 'uid-1',
+      email: 'ada@example.com',
+      phoneNumber: null,
+      customClaims: {groups: {'tenant-a': 'admin'}},
+    });
+    mockGetDocument.mockResolvedValue({id: 'uid-1', groups: {'tenant-a': 'admin'}});
+  });
+
+  it('removes the group from published claims rather than republishing a stale map', async () => {
+    await User.Helper.remove({id: 'uid-1', group: 'tenant-a'});
+    const claims = publishedClaims();
+    // Positive control: claims really were published on this path.
+    expect(mockSetCustomUserClaims).toHaveBeenCalledTimes(1);
+    expect(claims.groups).toBeDefined();
+    // The removed group must not survive into the signed token.
+    expect(claims.groups['tenant-a']).toBeUndefined();
+  });
+
+  it('revokes refresh tokens when a group role is withdrawn', async () => {
+    await User.Helper.remove({id: 'uid-1', group: 'tenant-a'});
+    expect(mockRevokeRefreshTokens).toHaveBeenCalledWith('uid-1');
+  });
+
+  it('revokes refresh tokens when an existing role is replaced', async () => {
+    await User.Helper.updateRole({id: 'uid-1', group: 'tenant-a', role: 'viewer'}, 'https://example.com');
+    // Positive control: the replacement really was published.
+    expect(publishedClaims().groups['tenant-a']).toBe('viewer');
+    expect(mockRevokeRefreshTokens).toHaveBeenCalledWith('uid-1');
+  });
+
+  it('does not revoke on a pure grant of a group the user did not hold', async () => {
+    await User.Helper.updateRole({id: 'uid-1', group: 'tenant-b', role: 'admin'}, 'https://example.com');
+    // Positive control: the grant was published, so the absence of a revoke below
+    // reflects the grant path and not a call that never happened.
+    expect(publishedClaims().groups['tenant-b']).toBe('admin');
+    expect(mockRevokeRefreshTokens).not.toHaveBeenCalled();
+  });
+
+  it('preserves other group memberships when one is removed', async () => {
+    mockGetDocument.mockResolvedValue({id: 'uid-1', groups: {'tenant-a': 'admin', 'tenant-b': 'viewer'}});
+    await User.Helper.remove({id: 'uid-1', group: 'tenant-a'});
+    const claims = publishedClaims();
+    expect(claims.groups['tenant-b']).toBe('viewer');
+    expect(claims.groups['tenant-a']).toBeUndefined();
+  });
+
+  it('publishes a group claim on the first grant, when the document has no groups yet', async () => {
+    mockGetUser.mockResolvedValue({uid: 'uid-1', email: 'ada@example.com', phoneNumber: null, customClaims: {}});
+    mockGetDocument.mockResolvedValue({id: 'uid-1'});
+    await User.Helper.updateRole({id: 'uid-1', group: 'tenant-a', role: 'admin'}, 'https://example.com');
+    expect(publishedClaims().groups).toEqual({'tenant-a': 'admin'});
+    expect(mockRevokeRefreshTokens).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
PR #77 was merged before its final documentation commit landed — an orchestration error on my side, not a gap in the original work. **All source fixes are already on `main`** (`authorityReduced`, `serverOnlyFields`, the scoped `revokeRefreshTokens`, the locally-derived claims). This restores the documentation and tests that described and proved them.

## What this adds

**The claims-promotion mechanism**, stated as mechanism rather than caveat:
- `roleUpdateCall` copies the user document's `groups` map into Firebase Auth custom claims.
- An injected map is therefore **promoted from a mutable document field into a signed token**.
- **The claim outlives the document** — cleaning up `user/{uid}` does not retract it.
- The call lives in this library, so it can be **invisible in consumer source** while still setting claims on their behalf.

**The admission rule** that replaced "non-authorization field" — which is precisely what let the payment-provider identifiers into the creation allow-list:

> Admit a field only if the caller is the party who knows its correct value.

That keeps `ads` creatable (the user knows their own AdSense client/slot; a wrong value misconfigures only their own placements) while excluding `bcId`/`bsId`/`bsiId`/`bst`/`but`/`buq`/`account`, whose values are produced by a server-side call or designate tenancy.

**The revocation caveat, documented alongside the call.** `revokeRefreshTokens` stops *new* ID tokens being minted, but outstanding ones stay cryptographically valid until expiry unless the relying party passes `checkRevoked`. Shipping the call without that note would produce false confidence — it would look fixed. Both halves are documented together in the JSDoc, CHANGELOG, README and instructions.

**Tests (+75 lines)** including that `creatableProfileFields` and `serverOnlyFields` stay **disjoint**, with a non-emptiness control so an empty intersection cannot come from an empty list.

## Verification

- `npm test` → **297 tests, 23 files**, all passing.
- Lint and build clean.
- Leak check on the diff: zero references to any private consumer.

Documentation and tests only; no `src/` changes.