### PR TITLE
docs: record the staged-landing ordering rule and commit-attribution policy

### DIFF
--- a/.github/instructions/cross-repo.instructions.md
+++ b/.github/instructions/cross-repo.instructions.md
@@ -160,6 +160,18 @@ A refuted finding is a real deliverable. Disproving a suspected vulnerability pr
 and wrong fixes. Never quietly drop a claim you disproved — write down what you checked and why it
 was clean.
 
+### 3.5 Order staged work so a partial landing is inert, not misleading
+
+When a change lands in stages — or is merged before you have finished — **sequence the stages so
+that stopping halfway leaves the repository safe rather than dishonest.**
+
+Code first, then the documentation and CHANGELOG that describe it. If the docs land first, the
+package advertises a guarantee it does not yet provide, and a consumer who reads the CHANGELOG will
+act on it. That is the failure mode nobody catches later.
+
+Same principle as §2.7: **false confidence is worse than a documented gap.** A documented gap gets
+fixed; a false one gets relied upon.
+
 ---
 
 ## 4. Breaking-change discipline for a published package
@@ -189,6 +201,10 @@ yours.
   form is self-cancelling when wrong.
 - **State-dependent claims carry an implicit timestamp.** A hash, a test count or a merge check must
   be re-measured, not re-quoted.
+- **Never add co-authorship attribution.** No `Co-authored-by:` trailer on any commit, pull request
+  or merge, regardless of tooling defaults. A rebase, amend or squash re-creates commit messages, so
+  re-check after one: `git log <base>..HEAD --format='%B' | grep -ci 'co-authored-by'` must print
+  `0` — and positive-control the grep, because a zero from an untested probe is not evidence.
 - **Public repository hygiene:** never add a reference to a private consumer repository, its
   infrastructure, project identifiers, service accounts, internal data model or security findings.
   Generic security lessons are fine; the identity of who was affected is not.


### PR DESCRIPTION
Propagates two additions from the canonical playbook. Documentation only — no code, no API or behaviour change.

### §3.5 — Order staged work so a partial landing is inert, not misleading

When a change lands in stages, sequence them so stopping halfway leaves the repository safe rather than dishonest: **code first, then the documentation and CHANGELOG that describe it.**

For a published package the stakes are higher than for an application: if the docs land first, the package advertises a guarantee it does not yet provide, and a consumer who reads the CHANGELOG will act on it. Same principle as the existing §2.7 — **false confidence is worse than a documented gap.** A documented gap gets fixed; a false one gets relied upon.

### Commit-attribution policy

Records that commits, pull requests and merges must never carry `Co-authored-by:` attribution, regardless of tooling defaults, with the post-rebase check — and requires positive-controlling that check, since a `0` from an untested grep is not evidence.

### Verification

The body below the `## 1.` anchor is **byte-identical to the canonical playbook**, confirmed by SHA-256; the repo-specific preamble is untouched. Extraction is anchored on content rather than line numbers.

This file is also gated for public-repository hygiene: scanned for private repository names, internal finding identifiers, environment names and infrastructure references — **clean**, with a positive control proving the scanner matches those patterns when they are present.