### PR TITLE
docs: record the inert-control pattern and two verification corrections

### DIFF
--- a/.github/instructions/cross-repo.instructions.md
+++ b/.github/instructions/cross-repo.instructions.md
@@ -201,10 +201,26 @@ yours.
   form is self-cancelling when wrong.
 - **State-dependent claims carry an implicit timestamp.** A hash, a test count or a merge check must
   be re-measured, not re-quoted.
+- **A control can exist, pass its tests, and still be inert.** The code is correct and the tests are
+  honest, but an **external precondition owned by someone else** is missing — a caller that never
+  supplies the input, a database index that was never created, an operational setting nobody
+  applied. For any control you ship, name what must be true *outside this package* for it to
+  actually run. Beware best-effort paths that degrade to a warning: their failure is
+  indistinguishable from "nothing to do".
+- **A green suite can be self-contradictory.** Two individually-passing tests can encode opposite
+  models of the same behaviour; no per-test review and no coverage metric reveals it, because
+  coverage is complete. Only the test that *composes* them fails. When a comment and the code
+  disagree, write the composed test before believing either.
 - **Never add co-authorship attribution.** No `Co-authored-by:` trailer on any commit, pull request
   or merge, regardless of tooling defaults. A rebase, amend or squash re-creates commit messages, so
   re-check after one: `git log <base>..HEAD --format='%B' | grep -ci 'co-authored-by'` must print
   `0` — and positive-control the grep, because a zero from an untested probe is not evidence.
+  **A clean message check is necessary but NOT sufficient.** GitHub's squash merge generates
+  `Co-authored-by:` trailers **server-side, from the authorship of the squashed commits**. A branch
+  whose every commit message greps clean still produces a merge commit carrying the trailer if any
+  commit's *author* differs from the merging identity, and a local `commit-msg` hook cannot
+  intercept it — it never runs. So also assert authorship:
+  `git log <base>..HEAD --format='%an|%cn'` must show only expected identities.
 - **Public repository hygiene:** never add a reference to a private consumer repository, its
   infrastructure, project identifiers, service accounts, internal data model or security findings.
   Generic security lessons are fine; the identity of who was affected is not.


### PR DESCRIPTION
Propagates three rules from the canonical playbook, all earned in practice this week. **Documentation only — no code, no behaviour change.**

### 1. A control can be present, correct, fully tested — and still inert

Three separate instances in one engagement. In each, the code was right and the tests were honest; what was missing was an **external precondition owned by somebody else**:

- a replay-protection middleware whose enforcement is opt-in, where **no caller supplies the input**;
- a counter-leak "fix" that was a **doc comment** telling operators not to enable a setting;
- a recovery sweep that requires a composite index nobody had shipped — and because the query is best-effort, its absence surfaces only as a `warn`, so the sweep **silently returns zero**.

No amount of reviewing the implementation finds these, because the implementation is not wrong. So: for any control, name what must be true *outside this repository* for it to actually run — a caller that supplies the input, an index that exists, an operational setting somebody applied — and verify that too. **A documented prohibition is not a control.**

The most dangerous shape is a best-effort path that degrades to a warning, because its failure is indistinguishable from "nothing to do".

### 2. A green test suite can be self-contradictory

A sweep was refunding money for spend that had really happened. The comment in the same commit claimed the **opposite** behaviour — and **both behaviours were covered by green tests that were never composed**.

Two individually-passing tests encoding contradictory models are invisible to per-test review and to coverage metrics, because coverage is *complete*. Only the test that composes them fails. **When a comment and the code disagree, write the composed test before believing either.**

### 3. The attribution check must assert authorship, not message text

The rule shipped previously said to grep commit messages for `Co-authored-by:`. That check is **necessary but not sufficient**, and it failed in practice: a branch whose every commit message grepped clean produced a squash-merge commit carrying the trailer, because GitHub generates it **server-side from commit authorship**. A local `commit-msg` hook cannot intercept it — it never runs. The rule now also requires asserting `git log <base>..HEAD --format='%an|%cn'`.

### Verification

The body below the `## 1.` anchor is **byte-identical to the canonical playbook**, confirmed by SHA-256 with a control proving the private and public variants hash differently (so the comparison discriminates). The per-repo preamble above the anchor is untouched. Extraction is anchored on content, not line numbers.

This file is additionally gated for public-repository hygiene: scanned for private repository names, internal finding identifiers, environment names and infrastructure references — **clean**, with a positive control proving the scanner matches those patterns when present.