### PR TITLE
docs: a security fix that removes capability is a regression

### DIFF
--- a/.github/instructions/cross-repo.instructions.md
+++ b/.github/instructions/cross-repo.instructions.md
@@ -211,6 +211,20 @@ yours.
   models of the same behaviour; no per-test review and no coverage metric reveals it, because
   coverage is complete. Only the test that *composes* them fails. When a comment and the code
   disagree, write the composed test before believing either.
+- **A change that removes capability is a REGRESSION, even when the motive is security.** A closed
+  grammar, allow-list or schema must be **complete, not minimal** — the risk usually comes from
+  accepting *arbitrary input*, not from the *number of legitimate options*. For a published package
+  this is sharper still: narrowing an accepted input set is a **breaking change** for consumers,
+  whatever the motivation. If a control cannot be built without losing behaviour, that is a
+  trade-off to surface explicitly, never a silent default.
+- **An automated gate cannot see a functionality regression.** Analyzer, tests and a build can all
+  pass on a change that silently removes features. Every automated gate is code-facing. When a
+  change **narrows** an interface, add an **inventory test** asserting what must still be there —
+  the capability equivalent of a positive control.
+- **Parameter binding protects values, not identifiers.** A column name, table name, sort field or
+  operator cannot be bound — it must come from an allow-list, with the caller sending a *key* that
+  is mapped, never a string that reaches the query text. "We bind everything, so we're safe" is a
+  plausible claim that becomes false the moment one input names an identifier.
 - **Never add co-authorship attribution.** No `Co-authored-by:` trailer on any commit, pull request
   or merge, regardless of tooling defaults. A rebase, amend or squash re-creates commit messages, so
   re-check after one: `git log <base>..HEAD --format='%B' | grep -ci 'co-authored-by'` must print


### PR DESCRIPTION
Propagates four rules from the canonical playbook. **Documentation only — no code, no behaviour change.**

The first is the most important, and it came directly from the repository owner rejecting a PR that was otherwise ready to merge.

### 1. A security fix that removes capability is a REGRESSION, not a fix

A PR closed a genuine SQL-injection surface by replacing client-supplied SQL with a closed filter grammar — and in doing so **silently removed twelve user-facing filters**, cutting a dashboard from roughly 18 filters to 5, including an entire admin-only block and two selectors.

The security reasoning was wrong in a subtle and tempting way. The injection risk came from accepting **arbitrary input** (raw SQL), *not* from the **number of legitimate options**. Safety needs an allow-list of column names, type-checked values bound as named parameters, and a server-authored tenant scope — **none of which require a smaller option set**. "Reduce the surface" is not equivalent to "secure the surface".

So: **a closed grammar, allow-list or schema must be complete, not minimal.** If a control genuinely cannot be implemented without losing behaviour, that is a trade-off requiring an **explicit owner decision** — never a silent default.

### 2. An automated gate cannot see a functionality regression

The analyzer, 974 tests and a release build all passed on the change that removed those twelve filters. **Every automated gate is code-facing.** When a change *narrows* an interface, the test that matters is the one asserting what must still be there — an **inventory test**. That is the capability equivalent of a positive control, and it belongs on both sides of a client/server contract so a narrowing at either layer fails loudly.

### 3. Parameter binding protects values, not identifiers

A column name, table name, sort field or operator **cannot be bound**. It must come from a server-side allow-list, with the caller sending a *key* that is mapped — never a string that reaches the query text. "We bind everything, so we are safe" is a plausible-sounding claim that becomes false the moment one input names an identifier. Worth stating explicitly wherever such a case is implemented, because it is easy for a later reader to over-generalise from the surrounding code.

### 4. A verification step can be wrong for its context while looking rigorous

A re-authoring task was given the check "prove only authorship changed: `git diff <old-head> HEAD` must be empty" — while the same instruction also required rebasing onto a newer base. Those are mutually unsatisfiable: after a rebase the diff necessarily contains everything the base gained. **An instruction that cannot be satisfied invites a false pass.** The correct form compares the patch the branch itself introduces, before and after, and requires them byte-identical.

### Verification

Body below the `## 1.` anchor is **byte-identical to the canonical playbook**, confirmed by SHA-256, with a control proving the private and public variants hash differently so the comparison discriminates. Preamble untouched; extraction anchored on content, not line numbers.

Additionally gated for public-repository hygiene: scanned for private repository names, internal finding identifiers, environment names and infrastructure references — **clean**, with a positive control proving the scanner matches when such patterns are present.
