### PR TITLE
docs: the permissive side lands first when two sides change together

### DIFF
--- a/.github/instructions/cross-repo.instructions.md
+++ b/.github/instructions/cross-repo.instructions.md
@@ -221,6 +221,13 @@ yours.
   pass on a change that silently removes features. Every automated gate is code-facing. When a
   change **narrows** an interface, add an **inventory test** asserting what must still be there —
   the capability equivalent of a positive control.
+- **When a package and its consumers must change together, the PERMISSIVE side ships first.**
+  Whichever side *widens* what is accepted must be released and adopted before the side that starts
+  depending on it. Widening is backward-compatible; depending on a widening that hasn't shipped is
+  not. For a published package this is sharper than in a single service, because you cannot deploy
+  your consumers — a version that *requires* a new input is a breaking change the moment it
+  publishes, while a version that *accepts* one is safe. So: accept the new input in release N,
+  let consumers adopt it, and only require it in a later major.
 - **Parameter binding protects values, not identifiers.** A column name, table name, sort field or
   operator cannot be bound — it must come from an allow-list, with the caller sending a *key* that
   is mapped, never a string that reaches the query text. "We bind everything, so we're safe" is a


### PR DESCRIPTION
Propagates one rule from the canonical playbook. **Documentation only — no code, no behaviour change.**

### When two sides must change together, the PERMISSIVE side lands first

Not "server first". Not "client first". **Whichever side widens what is accepted goes ahead of the side that starts depending on it.** Widening is backward-compatible; depending on a widening that has not shipped is not.

Both directions occurred in the same engagement, days apart, which is why the slogan form is dangerous — it is right half the time and causes an outage the other half:

- **Server first.** The backend had to *accept* a new request header in its CORS allow-list before the client began sending it. Ship the client first and the browser's **preflight** rejects the request before it ever reaches the backend — a full outage of those routes for web users, surfacing as a generic CORS error rather than an auth failure, which makes it needlessly hard to diagnose under pressure.
- **Client first.** Replay-protection middleware had to stay opt-in until clients were sending the key. Require it first and every already-installed binary breaks the moment enforcement turns on — and you cannot recall an installed app.

The asymmetry is the whole point: in the first case the *server* is widening, in the second the *client* is. Identify which side is widening, ship that side, let it propagate, and only then ship the side that depends on it.

Two practical consequences:

- **Merging is not deploying.** Where CI carries a deploy guard, the ordering constraint binds the **deploy**, not the merge — so this need not block landing work. But order the merges to match the deploy order anyway, so `main` is never in a state where deploying it in the obvious order breaks something.
- **Record the dependency where the operator will see it.** A PR body disappears once merged. If a deploy must not happen before another, that belongs in the deployment instructions or in a comment at the affected code — not only in a pull request description.

### Verification

The body below the `## 1.` anchor is **byte-identical to the canonical playbook**, confirmed by SHA-256, with a control proving the private and public variants hash differently so the comparison discriminates. The per-repo preamble above the anchor is untouched. Extraction is anchored on document content, not line numbers.

Additionally gated for public-repository hygiene: scanned for private repository names, internal finding identifiers, environment names and infrastructure references — **clean**, with a positive control proving the scanner matches when such patterns are present.
