### PR TITLE
docs: check a discriminator exists for the whole data history

### DIFF
--- a/.github/instructions/cross-repo.instructions.md
+++ b/.github/instructions/cross-repo.instructions.md
@@ -207,6 +207,13 @@ yours.
   applied. For any control you ship, name what must be true *outside this package* for it to
   actually run. Beware best-effort paths that degrade to a warning: their failure is
   indistinguishable from "nothing to do".
+- **Before using a record as a discriminator over historical data, ask whether it exists for the
+  WHOLE history — not merely whether it is durable.** These are different questions and the first is
+  the one that bites. A field introduced by your own recent change is the **highest-risk** case,
+  because it looks canonical precisely because it is clean, new and well-structured. Two cheap
+  habits beat insight here: ask questions that send you **to the artifact** rather than to reason
+  about it, and reason about **consequence-if-wrong** — noticing a tool would be *useless* is often
+  easier than noticing it would be *unsafe*, and arrives at the same fix.
 - **A green suite can be self-contradictory.** Two individually-passing tests can encode opposite
   models of the same behaviour; no per-test review and no coverage metric reveals it, because
   coverage is complete. Only the test that *composes* them fails. When a comment and the code


### PR DESCRIPTION
Propagates one rule from the canonical playbook. **Documentation only — no code, no behaviour change.**

### Before using a record as a discriminator over historical data, ask whether it exists for the *whole* history

Not merely whether it is **durable**. These are different questions, and the first is the one that bites.

A backfill in this engagement needed to tell two classes of record apart. The obvious discriminator was the presence of a particular payment record, and the risk flagged for checking was whether those records were reaped by a TTL policy. They were not — durable, as expected.

**The actual defect was that the record type had not always existed.** It was introduced by a remediation landed *the previous day*, while the data it was being used to classify went back **seventeen months**. Every older record lacked it, and would have been classified wrongly.

**A field introduced by your own recent change is the highest-risk case**, precisely because it looks canonical: it is clean, new, well-structured and obviously "the modern way". Age is invisible in the code.

Two cheap habits beat insight here, and both worked in practice:

- **Ask questions that send you to the artifact** rather than to reason about it. The check that caught this was one `git log` away from the check that had been asked for — going to the history at all is what mattered, not asking the right question about it.
- **Reason about consequence-if-wrong.** Noticing the tool would be *useless* (every historical record failing attribution, so it does nothing) came before noticing it would be *unsafe*, and led to the same fix. The cheaper realisation arrived first.

### Verification

Body below the `## 1.` anchor is **byte-identical to the canonical playbook**, confirmed by SHA-256, with a control proving the private and public variants hash differently so the comparison discriminates. Preamble untouched; extraction anchored on content, not line numbers.

Additionally gated for public-repository hygiene: scanned for private repository names, internal finding identifiers, environment names and infrastructure references — **clean**, with a positive control proving the scanner matches when such patterns are present.
