### PR TITLE
docs: a change owns the failure paths it makes more frequent

### DIFF
--- a/.github/instructions/cross-repo.instructions.md
+++ b/.github/instructions/cross-repo.instructions.md
@@ -218,6 +218,12 @@ yours.
   models of the same behaviour; no per-test review and no coverage metric reveals it, because
   coverage is complete. Only the test that *composes* them fails. When a comment and the code
   disagree, write the composed test before believing either.
+- **A change owns the failure paths it makes more frequent, even ones it never edited.** If your
+  change converts a rarely-hit error path into a routine one — by adding validation, tightening a
+  schema, or surfacing refusals that used to be impossible — that path is now part of your blast
+  radius. A latent bug on it becomes an active one. A diff-based review structurally cannot surface
+  this, because the offending code is unchanged and therefore absent from the diff. For a published
+  package this compounds: consumers hit the newly-frequent path without having changed anything.
 - **A change that removes capability is a REGRESSION, even when the motive is security.** A closed
   grammar, allow-list or schema must be **complete, not minimal** — the risk usually comes from
   accepting *arbitrary input*, not from the *number of legitimate options*. For a published package


### PR DESCRIPTION
Propagates one rule from the canonical playbook. **Documentation only — no code, no behaviour change.**

### A change owns the failure paths it makes more frequent, even ones it never edited

A migration in this engagement inverted an image-deletion ordering bug it had **not** introduced: the storage object was deleted *before* the document write, so a refused write destroyed a file the surviving record still pointed at. The bug was pre-existing and latent — it needed a refusal to fire, and refusals were rare.

**What made it urgent is that the same change converted refusals from rare to routine** — new validation, a tightened schema, and previously-impossible rejections now surfacing. A change that leaves a latent bug untouched while multiplying its trigger rate **has made things worse**, even though it edited none of that code.

So when reviewing, ask not only *what does this modify* but **what does this make more frequent**.

The uncomfortable part: **a diff-based review structurally cannot surface this.** The offending code is unchanged, so it is absent from the diff — the reviewer would have to go looking for it on a hunch. That makes it a scoping question to ask deliberately rather than something to notice.

Two shapes worth watching for:

- adding validation, tightening a schema, or surfacing refusals that were previously unreachable — everything downstream of those refusals is now in scope;
- raising the invocation rate of any existing path, not only error paths. Anything whose execution frequency a change increases inherits that change's scrutiny.

### Verification

Body below the `## 1.` anchor is **byte-identical to the canonical playbook**, confirmed by SHA-256, with a control proving the private and public variants hash differently so the comparison discriminates. Preamble untouched; extraction anchored on content, not line numbers.

For a published package this compounds: consumers hit the newly-frequent path without having changed anything on their side.

Additionally gated for public-repository hygiene: scanned for private repository names, internal finding identifiers, environment names and infrastructure references — **clean**, with a positive control proving the scanner matches when such patterns are present.
